### PR TITLE
protect test writers from accidental invocation of checkmate default

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -11,3 +11,9 @@ pub fn checkmate_command(argument: &str) -> Output {
         .output()
         .expect("command with args failed")
 }
+
+#[should_panic]
+#[test]
+fn empty_checkmate_command() {
+    checkmate_command("");
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,10 +2,7 @@ use std::process::Command;
 use std::process::Output;
 
 pub fn checkmate_command(argument: &str) -> Output {
-    assert!(
-        "" != argument,
-        "Don't pass an empty string to this function."
-    );
+    assert_eq!(false, argument.trim().is_empty());
     Command::new("./target/debug/cargo-checkmate")
         .arg(argument)
         .output()
@@ -14,6 +11,23 @@ pub fn checkmate_command(argument: &str) -> Output {
 
 #[should_panic]
 #[test]
-fn empty_checkmate_command() {
+fn empty_checkmate_argument() {
     checkmate_command("");
+}
+
+#[should_panic]
+#[test]
+fn whitespace_checkmate_argument() {
+    checkmate_command(" ");
+}
+
+#[should_panic]
+#[test]
+fn more_whitespace_checkmate_argument() {
+    use std::str;
+    let whitespace = vec![
+        9, 10, 11, 12, 13, 32, 133, 160, 0xE2, 0x80, 0x8E, 0xE2, 0x80, 0x8F, 0xE2, 0x80, 0xA8,
+        0xE2, 0x80, 0xA9,
+    ];
+    checkmate_command(str::from_utf8(&whitespace).unwrap());
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,6 +2,10 @@ use std::process::Command;
 use std::process::Output;
 
 pub fn checkmate_command(argument: &str) -> Output {
+    assert!(
+        "" != argument,
+        "Don't pass an empty string to this function."
+    );
     Command::new("./target/debug/cargo-checkmate")
         .arg(argument)
         .output()


### PR DESCRIPTION
It would be sad if a well-intended test engineer fell into an infinite rabbit hole.